### PR TITLE
Revalidate multipass for customer before checking out.

### DIFF
--- a/nuxt-shopify-accounts/store/account.js
+++ b/nuxt-shopify-accounts/store/account.js
@@ -199,7 +199,7 @@ export const actions = {
     }
   },
 
-  async multipassLogin ({ state }) {
+  async multipassLogin ({ state }, payload) {
     // TODO: figure out remote ip
     if (process.browser) {
       const { host, protocol } = window.location
@@ -207,7 +207,7 @@ export const actions = {
       const customerData = {
         ...state.customer,
         // remote_ip: req.ip,
-        return_to: `${protocol}//${host}/account`
+        return_to: payload && payload.returnTo || `${protocol}//${host}/account`
       }
       return {
         multipassUrl: multipassify.generateUrl(customerData, process.env.myshopifyDomain)

--- a/nuxt-shopify-accounts/store/cart.js
+++ b/nuxt-shopify-accounts/store/cart.js
@@ -313,6 +313,15 @@ export const state = () => ({
 
           await dispatch('saveCheckoutUrl', url)
 
+          // revalidate customer login with multipass
+          if (rootState.account.customer && rootState.account.customerAccessToken) {
+            const payload = { returnTo: url }
+            const response = await dispatch("account/multipassLogin", payload, { root: true })
+            if (response.multipassUrl) {
+              url = response.multipassUrl
+            }
+          }
+
           window.location = url
         }
       },


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [[NS-202](https://nacelle.atlassian.net/browse/NS-202)] **Checkout Issue**

We were seeing customers being logged in on the storefront, but not on checkout.

### WHAT is this pull request doing?

- Modifies `multipassLogin` account action to accept a payload with a returnTo property so we can utilize it be a bit more multipurpose (in our case so we can pass it the checkout url).
- Before we redirect to Checkout, we now revalidate the Multipass login for customers, so we can make sure that they are logged in when the land on Shopify's Checkout page.