### PR TITLE
DD-239 Account Activation URL Fix

### DIFF
--- a/nuxt-shopify-accounts/components/account/ActivateForm.vue
+++ b/nuxt-shopify-accounts/components/account/ActivateForm.vue
@@ -111,8 +111,8 @@ export default {
       this.form.resetToken = this.$route.query.token
       this.form.customerId = this.$route.query.id
     }
-    if (this.mode === 'activate') {
-      this.form.activationUrl = this.$route.query.activationUrl
+    if (this.mode === 'activate' && process.client) {
+      this.form.activationUrl = window.location
     }
   },
   methods: {


### PR DESCRIPTION
Updates `AccountForm.vue` to use `window.location` instead of `this.$route.query.activationUrl` in `created` hook