### PR TITLE
add axios dependency

### DIFF
--- a/nuxt-shopify-accounts/package-lock.json
+++ b/nuxt-shopify-accounts/package-lock.json
@@ -2879,6 +2879,14 @@
         "postcss-value-parser": "^4.1.0"
       }
     },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "babel-helper-vue-jsx-merge-props": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-2.0.3.tgz",
@@ -6106,6 +6114,11 @@
           }
         }
       }
+    },
+    "follow-redirects": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.2.tgz",
+      "integrity": "sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/nuxt-shopify-accounts/package.json
+++ b/nuxt-shopify-accounts/package.json
@@ -20,6 +20,7 @@
     "@nacelle/client-js-sdk": "^3.1.1",
     "@nuxtjs/dotenv": "^1.4.1",
     "@nuxtjs/pwa": "^3.3.5",
+    "axios": "^0.21.1",
     "cookie-universal-nuxt": "^2.1.4",
     "dotenv": "^8.0.0",
     "es-cookie": "^1.2.0",


### PR DESCRIPTION
**What This PR Does**
- The `nuxt-shopify-accounts` demo breaks because `axios` is undefined
- This adds axios

**How To Test**
- Run `npm install && npm build` in `/nuxt-starter-accounts` on `master` branch.  Notice error
- Run `npm install && npm build` in `/nuxt-starter-accounts` on `DD-406--axios-accounts` branch.  Notice no errors